### PR TITLE
Added support for "Number" field type. Bumped version to 2.1.2.

### DIFF
--- a/classes/AdminPage.Menu.class.php
+++ b/classes/AdminPage.Menu.class.php
@@ -8,7 +8,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageMenu_2_1_1 extends sapAdminPage_2_1_1 {
+class sapAdminPageMenu_2_1_2 extends sapAdminPage_2_1_2 {
 	
 	public $setup_function = 'add_menu_page'; // WP function to register the page
 

--- a/classes/AdminPage.Submenu.class.php
+++ b/classes/AdminPage.Submenu.class.php
@@ -8,7 +8,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSubmenu_2_1_1 extends sapAdminPage_2_1_1 {
+class sapAdminPageSubmenu_2_1_2 extends sapAdminPage_2_1_2 {
 	
 	public $setup_function = 'add_submenu_page'; // WP function to register the page
 	

--- a/classes/AdminPage.Themes.class.php
+++ b/classes/AdminPage.Themes.class.php
@@ -8,7 +8,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageThemes_2_1_1 extends sapAdminPage_2_1_1 {
+class sapAdminPageThemes_2_1_2 extends sapAdminPage_2_1_2 {
 	
 	public $setup_function = 'add_theme_page'; // WP function to register the page
 

--- a/classes/AdminPage.class.php
+++ b/classes/AdminPage.class.php
@@ -7,7 +7,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPage_2_1_1 {
+class sapAdminPage_2_1_2 {
 
 	public $title;
 	public $menu_title;

--- a/classes/AdminPageSection.class.php
+++ b/classes/AdminPageSection.class.php
@@ -7,7 +7,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSection_2_1_1 {
+class sapAdminPageSection_2_1_2 {
 
 	// Page defaults
 	public $id; // unique id for this section

--- a/classes/AdminPageSetting.Address.class.php
+++ b/classes/AdminPageSetting.Address.class.php
@@ -7,7 +7,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingAddress_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingAddress_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	/*
 	 * Size of this textarea

--- a/classes/AdminPageSetting.Editor.class.php
+++ b/classes/AdminPageSetting.Editor.class.php
@@ -7,7 +7,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingEditor_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingEditor_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'wp_kses_post';
 	

--- a/classes/AdminPageSetting.HTML.class.php
+++ b/classes/AdminPageSetting.HTML.class.php
@@ -14,7 +14,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingHTML_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingHTML_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'sanitize_text_field';
 

--- a/classes/AdminPageSetting.Image.class.php
+++ b/classes/AdminPageSetting.Image.class.php
@@ -7,7 +7,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingImage_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingImage_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'absint';
 

--- a/classes/AdminPageSetting.Number.class.php
+++ b/classes/AdminPageSetting.Number.class.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Register, display and save a number field setting in the admin menu
+ * 
+ * By default, it allows positive and negative numbers. To only allow positive numbers,
+ * add "sanitize_callback" => "absint" to your add_setting() $args array.
+ * 
+ * Example:
+ * $sap->add_setting(
+ *    'page-id',
+ *    'section-id',
+ *    'number',
+ *    [
+ *        'id'			=> 'field-id',
+ *        'title'			=> __( 'Some number:', '' ),
+ *        'sanitize_callback' => 'absint', // Add this if you want to allow only positive numbers.
+ *    ]
+ *);
+ * 
+ * @since 2.1.2
+ * @package Simple Admin Pages
+ */
+
+class sapAdminPageSettingNumber_2_1_2 extends sapAdminPageSetting_2_1_2 {
+
+	public $sanitize_callback = 'intval';
+
+	/**
+	 * Display this setting
+	 * @since 1.0
+	 */
+	public function display_setting() {
+		?>
+
+        <input name="<?php echo $this->get_input_name(); ?>" type="number" id="<?php echo $this->get_input_name(); ?>" value="<?php echo $this->value; ?>" class="regular-number" />
+
+		<?php
+
+		$this->display_description();
+
+	}
+
+}

--- a/classes/AdminPageSetting.OpeningHours.class.php
+++ b/classes/AdminPageSetting.OpeningHours.class.php
@@ -25,7 +25,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingOpeningHours_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingOpeningHours_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'sanitize_text_field';
 

--- a/classes/AdminPageSetting.Scheduler.class.php
+++ b/classes/AdminPageSetting.Scheduler.class.php
@@ -10,7 +10,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingScheduler_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingScheduler_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'sanitize_text_field';
 

--- a/classes/AdminPageSetting.Select.class.php
+++ b/classes/AdminPageSetting.Select.class.php
@@ -21,7 +21,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingSelect_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingSelect_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'sanitize_text_field';
 

--- a/classes/AdminPageSetting.SelectPost.class.php
+++ b/classes/AdminPageSetting.SelectPost.class.php
@@ -17,7 +17,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingSelectPost_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingSelectPost_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'intval';
 

--- a/classes/AdminPageSetting.SelectTaxonomy.class.php
+++ b/classes/AdminPageSetting.SelectTaxonomy.class.php
@@ -19,7 +19,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingSelectTaxonomy_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingSelectTaxonomy_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'intval';
 	

--- a/classes/AdminPageSetting.Text.class.php
+++ b/classes/AdminPageSetting.Text.class.php
@@ -7,7 +7,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingText_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingText_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'sanitize_text_field';
 

--- a/classes/AdminPageSetting.Textarea.class.php
+++ b/classes/AdminPageSetting.Textarea.class.php
@@ -9,7 +9,7 @@
  * @todo textareas should have an option to swap new lines for <br>s
  */
 
-class sapAdminPageSettingTextarea_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingTextarea_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	/*
 	 * Size of this textarea

--- a/classes/AdminPageSetting.Toggle.class.php
+++ b/classes/AdminPageSetting.Toggle.class.php
@@ -17,7 +17,7 @@
  * @package Simple Admin Pages
  */
 
-class sapAdminPageSettingToggle_2_1_1 extends sapAdminPageSetting_2_1_1 {
+class sapAdminPageSettingToggle_2_1_2 extends sapAdminPageSetting_2_1_2 {
 
 	public $sanitize_callback = 'sanitize_text_field';
 

--- a/classes/AdminPageSetting.class.php
+++ b/classes/AdminPageSetting.class.php
@@ -16,7 +16,7 @@
  * @package Simple Admin Pages
  */
 
-abstract class sapAdminPageSetting_2_1_1 {
+abstract class sapAdminPageSetting_2_1_2 {
 
 	// Page defaults
 	public $id; // used in form fields and database to track and store setting

--- a/classes/Library.class.php
+++ b/classes/Library.class.php
@@ -1,5 +1,5 @@
 <?php
-if ( !class_exists( 'sapLibrary_2_1_1' ) ) {
+if ( !class_exists( 'sapLibrary_2_1_2' ) ) {
 /**
  * This library class loads and provides access to the correct version of the
  * Simple Admin Pages library.
@@ -7,10 +7,10 @@ if ( !class_exists( 'sapLibrary_2_1_1' ) ) {
  * @since 1.0
  * @package Simple Admin Pages
  */
-class sapLibrary_2_1_1 {
+class sapLibrary_2_1_2 {
 
 	// Version of the library
-	private $version = '2.1.1';
+	private $version = '2.1.2';
 
 	// A full URL to the library which is used to correctly link scripts and
 	// stylesheets.
@@ -168,6 +168,10 @@ class sapLibrary_2_1_1 {
 			case 'address' :
 				require_once('AdminPageSetting.Address.class.php');
 				return $this->get_versioned_classname( 'sapAdminPageSettingAddress' );
+
+			case 'number' :
+				require_once('AdminPageSetting.Number.class.php');
+				return $this->get_versioned_classname( 'sapAdminPageSettingNumber' );
 
 			default :
 


### PR DESCRIPTION
This PR adds support for "Number" field type.

By default, it allows negative and positive numbers. To allow only positive numbers, one can add `'sanitize_callback' = 'absint'` when calling `add_setting()` on the field.

